### PR TITLE
fix: Correct Renovate config for semver on submodules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,8 +3,12 @@
   "extends": [
     "config:base"
   ],
-  "git-submodules": {
-    "enabled": true,
-    "versioning": "semver"
-  }
+  "packageRules": [
+    {
+      "matchPackageUrls": ["https://github.com/noctalia-dev/noctalia-shell"],
+      "matchDatasources": ["git-tags"],
+      "versioning": "semver",
+      "extractVersion": "^v(?<version>.*)$"
+    }
+  ]
 }


### PR DESCRIPTION
This pull request corrects the Renovate configuration to properly handle semantic versioning for the `noctalia-shell` git submodule. The previous configuration was not specific enough, causing Renovate to fall back to tracking commit digests. This change ensures that Renovate will now track version tags.